### PR TITLE
feat: 🎸 「【サクミル】DM送付管理アプリver2」のairbyteコネクタの開発

### DIFF
--- a/airbyte-integrations/connectors/source-kintone/source_kintone/app_name_mapping/app_name.yaml
+++ b/airbyte-integrations/connectors/source-kintone/source_kintone/app_name_mapping/app_name.yaml
@@ -3,3 +3,4 @@
 "254": "web_dm_logs"
 "748": "paper_dm_logs"
 "1005": "ma_test_apps"
+"1155": "sakumiru_dm_management_apps"

--- a/airbyte-integrations/connectors/source-kintone/source_kintone/field_code_mapping/field_code_1155.yaml
+++ b/airbyte-integrations/connectors/source-kintone/source_kintone/field_code_mapping/field_code_1155.yaml
@@ -1,0 +1,6 @@
+"更新日時": "updated_at"
+"作成日時": "created_at"
+"更新者": "updated_by"
+"作成者": "created_by"
+"hubspot法人検索用_事業者名": "hubspot_company_name_search"
+"関連レコード一覧": "company_name"


### PR DESCRIPTION
## 背景
下記のサクミルが利用しているkintoneのDM管理アプリをbiqeueryに接続するための、airbyte作成
https://plex.cybozu.com/k/1155

[notion](https://www.notion.so/plexjobdirect/2024-04-12-d9421b7bf20a4a51a413a953cc171d4a?p=474fff8213d94a828b74e570fd8eee2e&pm=s)

## やったこと
1. ローカルairbyteにて、該当kintoneアプリのレコードを`data-management-sandbox-396902`に同期検証